### PR TITLE
feat: Store quiz in redis

### DIFF
--- a/app/crud/quiz_cache.py
+++ b/app/crud/quiz_cache.py
@@ -1,0 +1,23 @@
+import json
+import logging
+from redis.exceptions import RedisError
+from app.utils.redis_client import redis_client
+
+logger = logging.getLogger(__name__)
+QUIZ_TTL = 3600  # 60 mins
+
+def store_quiz(quiz_id: str, user_id: int, questions: list):
+    try:
+        redis_client.setex(
+            f"quiz:{quiz_id}",
+            QUIZ_TTL,
+            json.dumps({
+                "user_id": user_id,
+                "questions": questions
+            })
+        )
+        return True
+    
+    except RedisError:
+        logger.exception("Failed to cache quiz %s in Redis", quiz_id)
+        return False

--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -1,16 +1,16 @@
 from sqlalchemy.orm import Session
-from app import models
 from app.enums import Grade
+from app.models import User
 from app.utils.hashing import hash_password, verify_password
 
 def get_user(db: Session, google_id: str):
-    return db.query(models.User).filter(models.User.google_id == google_id).first()
+    return db.query(User).filter(User.google_id == google_id).first()
 
 def get_user_by_id(db: Session, user_id: int):
-    return db.query(models.User).filter(models.User.id == user_id).first()
+    return db.query(User).filter(User.id == user_id).first()
 
 def authenticate_user(db: Session, username: str, password: str):
-    user = db.query(models.User).filter(models.User.username == username).first()
+    user = db.query(User).filter(User.username == username).first()
     if not user:
         return None
     if not verify_password(password, user.password):
@@ -28,7 +28,7 @@ def create_google_user(
     institute: str,
     city: str,
     marketing: str):
-    user = models.User(
+    user = User(
         google_id=google_id,
         email=email,
         name=name,

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,4 +1,9 @@
-from .database import SessionLocal
+from datetime import datetime, timezone
+from fastapi import Cookie, Depends, HTTPException
+from sqlalchemy.orm import Session as DBSession
+from app.crud.user import get_user_by_id
+from app.database import SessionLocal
+from app.models import Session
 
 def get_db():
     db = SessionLocal()
@@ -6,3 +11,34 @@ def get_db():
         yield db
     finally:
         db.close()
+
+def get_current_user(
+    session_id: str = Cookie(None),
+    db: DBSession = Depends(get_db)
+):
+    if not session_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    db_session = (
+        db.query(Session)
+        .filter(Session.id == session_id)
+        .first()
+    )
+
+    if not db_session:
+        raise HTTPException(status_code=401, detail="Invalid session")
+    
+    if db_session.expires_at.tzinfo is None:
+        expires_at = db_session.expires_at.replace(tzinfo=timezone.utc)
+    else:
+        expires_at = db_session.expires_at
+
+    if expires_at < datetime.now(timezone.utc):
+        raise HTTPException(status_code=401, detail="Session expired")
+
+    user = get_user_by_id(db, db_session.user_id)
+
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+
+    return user

--- a/app/routers/quiz.py
+++ b/app/routers/quiz.py
@@ -1,13 +1,17 @@
 import json
 import os
 from typing import List
+import uuid
 
 from dotenv import load_dotenv
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from google import genai
 from pydantic import ValidationError
 
-from app.schemas.quiz import QuizQuestion, Subject, QUIZ_RESPONSE_SCHEMA
+from app.crud.quiz_cache import store_quiz
+from app.dependencies import get_current_user
+from app.models import User
+from app.schemas.quiz import QuizResponse, QuizQuestion, QuizQuestionSafe, Subject, QUIZ_RESPONSE_SCHEMA
 
 load_dotenv()
 
@@ -22,8 +26,8 @@ def get_genai_client():
 
 router = APIRouter(prefix="/quiz", tags=["Quiz"])
 
-@router.post("/generate-quiz", response_model=List[QuizQuestion])
-def generate_quiz(data: List[Subject]):
+@router.post("/generate-quiz", response_model=QuizResponse)
+def generate_quiz(data: List[Subject], current_user: User = Depends(get_current_user)):
     
     client = get_genai_client()
     syllabus_text = ""
@@ -57,8 +61,8 @@ Rules:
         
     try:
         quiz_data = json.loads(response.text)
-        return [QuizQuestion(**q) for q in quiz_data]
-
+        questions = [QuizQuestion(**q) for q in quiz_data]
+ 
     except json.JSONDecodeError:
         raise HTTPException(
             status_code=500,
@@ -70,3 +74,24 @@ Rules:
             status_code=500,
             detail="Model returned invalid data structure"
         )
+ 
+    quiz_id = str(uuid.uuid4())
+    
+    if not store_quiz(
+        quiz_id=quiz_id,
+        user_id=current_user.id,
+        questions=[q.model_dump() for q in questions],
+    ):
+        raise HTTPException(
+            status_code=503,
+            detail="Quiz generated but could not be stored. Please try again."
+        )
+ 
+    safe_questions = [
+        QuizQuestionSafe(
+            question=q.question,
+            options=q.options,
+        ) for q in questions
+    ]
+ 
+    return QuizResponse(quiz_id=quiz_id, questions=safe_questions)

--- a/app/schemas/quiz.py
+++ b/app/schemas/quiz.py
@@ -16,6 +16,14 @@ class QuizQuestion(BaseModel):
     correct_answer: str
     related_concepts: List[str]
         
+class QuizQuestionSafe(BaseModel):
+    question: str
+    options: List[str] = Field(min_length=4, max_length=4)
+ 
+class QuizResponse(BaseModel):
+    quiz_id: str
+    questions: List[QuizQuestionSafe]
+        
 QUIZ_RESPONSE_SCHEMA = {
     "type": "array",
     "items": {

--- a/app/utils/redis_client.py
+++ b/app/utils/redis_client.py
@@ -1,0 +1,8 @@
+import os
+import redis
+
+redis_client = redis.Redis(
+    host=os.getenv("REDIS_HOST", "localhost"),
+    port=int(os.getenv("REDIS_PORT", 6379)),
+    decode_responses=True
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ email-validator==2.3.0
 ruff==0.5.7
 pytest==9.0.2
 google-genai==1.55.0
+redis==7.4.0


### PR DESCRIPTION
# Related Issue
Fixes #12 

# Description

- Added a Redis utility and helper to store quizzes with a TTL.
- Once the model generates a quiz, it is stored in the server-side cache. Only the questions and options are returned to the frontend.